### PR TITLE
Allow all 'inet' addresses rather than just [xgf]e based interfaces

### DIFF
--- a/lib/junos-ez/ip_ports/classic.rb
+++ b/lib/junos-ez/ip_ports/classic.rb
@@ -175,9 +175,9 @@ class Junos::Ez::IPports::Provider::CLASSIC
     
     xml_data = @ndev.rpc.get_interface_information( 
       :terse => true,
-      :interface_name => '[xgf]e-*/*/*.*' )
+      )
     
-    ifa_list = xml_data.xpath('logical-interface[normalize-space(address-family/address-family-name) = "inet"]')    
+    ifa_list = xml_data.xpath('interface-information/logical-interface[normalize-space(address-family/address-family-name) = "inet"]')    
     
   end
   


### PR DESCRIPTION
Hi Jeremy,

I was looking to do pull some more information from interface addresses and found some low hanging fruit to include vlan interfaces (and pretty much any other interface as well, but I can only test so much on my home srx).

-casey
