### PR TITLE
RE0 does not always exist in a VC

### DIFF
--- a/lib/junos-ez/facts/personality.rb
+++ b/lib/junos-ez/facts/personality.rb
@@ -3,7 +3,7 @@ Junos::Ez::Facts::Keeper.define( :personality ) do |ndev, facts|
   uses :chassis, :routingengines  
   model = facts[:hardwaremodel]
 
-  examine = ( model != "Virtual Chassis" ) ? model : facts[:RE0][:model]
+  examine = ( model != "Virtual Chassis" ) ? model : facts.select {|k,v| k.match(/RE/) }.values[0][:model]
       
   facts[:personality] = case examine   
   when /^(EX)|(QFX)/


### PR DESCRIPTION
Select the first RE rather than hardcode RE0, which is not guaranteed to exist.
