### PR TITLE
Omit version for master RE if undeclared

### DIFF
--- a/lib/junos-ez/facts/version.rb
+++ b/lib/junos-ez/facts/version.rb
@@ -31,9 +31,11 @@ Junos::Ez::Facts::Keeper.define( :version ) do |ndev, facts|
       facts[ver_key] = $1                  
     end
     master_id = f_master
-    facts[:version] = 
-      facts[("version_" + "RE" + master_id).to_sym] || 
-      facts[('version_' + "FPC" + master_id).to_sym]
+    unless master_id.nil?
+      facts[:version] = 
+        facts[("version_" + "RE" + master_id).to_sym] || 
+        facts[('version_' + "FPC" + master_id).to_sym]
+    end
   else
     junos = swver.xpath('//package-information[name = "junos"]/comment').text
     junos =~ /\[(.*)\]/


### PR DESCRIPTION
On clustered, branch SRXs, show chassis routing-engine does not declare which device is the master. This causes fact generation to fail (with an exception) because it blindly expects a master_id to exist.

This addresses https://github.com/Juniper/ruby-junos-ez-stdlib/issues/12