### PR TITLE
Fix issue #42

### DIFF
--- a/lib/junos-ez/provider.rb
+++ b/lib/junos-ez/provider.rb
@@ -544,7 +544,7 @@ class Junos::Ez::Provider::Parent
       action = {'action' => 'replace' }
       result = @ndev.rpc.load_configuration( xml, action )
     rescue Netconf::RpcError => e      
-      errs = e.rsp.xpath('//rpc-error[error-severity = "error"]')
+      errs = e.rsp.xpath('//rpc-error')
       raise e unless errs.empty?
       e.rsp
     else


### PR DESCRIPTION
Netconf::raise_on_warning flag is set to default false in net-netconf module, no need to ignore warning here. If flag is set to true in script, it should raise exception if <rpc-reply> has warning <error-severtity>