### PR TITLE
Removing references to rake from gemspec

### DIFF
--- a/junos-ez-stdlib.gemspec
+++ b/junos-ez-stdlib.gemspec
@@ -1,5 +1,4 @@
 $LOAD_PATH.unshift 'lib'
-require 'rake'
 require 'junos-ez/version'
 
 Gem::Specification.new do |s|
@@ -10,6 +9,6 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/Juniper/ruby-junos-ez-stdlib'
   s.authors = ["Jeremy Schulman", "John Deatherage", "Nitin Kumar", "Priyal Jain", "Ganesh Nalawade"]
   s.email = 'jnpr-community-netdev@juniper.net'
-  s.files = FileList[ '*', 'lib/**/*.rb', 'examples/**/*.rb', 'docs/**/*.md' ]
+  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.add_dependency('netconf', ">= 0.2.5")
 end


### PR DESCRIPTION
Causes an issue when installing the gem on Ruby 2.3.0 when building with `rvm` and `docker`. Also, as far as I can tell, `rake` is not listed as a dependency or development dependency in the gemspec, and the only thing that requires it is the call to `FileList` in the gemspec itself.

Using `git` to compile that list of files is a perfectly acceptable and more lightweight method (see [rspec](https://github.com/rspec/rspec/blob/master/rspec.gemspec#L17), [rake itself](https://github.com/ruby/rake/blob/master/rake.gemspec#L17), etc).