### PR TITLE
Fix diff? method for newer JunOS versions

### DIFF
--- a/lib/junos-ez/utils/config.rb
+++ b/lib/junos-ez/utils/config.rb
@@ -169,7 +169,7 @@ class Junos::Ez::Config::Provider < Junos::Ez::Provider::Parent
   
   def diff?( rollback_id = 0 )
     raise ArgumentError, "invalid rollback #{rollback_id}" unless ( rollback_id >= 0 and rollback_id <= 50 )    
-    got = ndev.rpc.get_configuration( :compare=>'rollback', :rollback=> rollback_id.to_s )
+    got = ndev.rpc.get_configuration( :compare => 'rollback', :rollback => rollback_id.to_s, :format => 'text' )
     diff = got.xpath('configuration-output').text
     return nil if diff == "\n"
     diff


### PR DESCRIPTION
There is an issue getting the `diff?` from a switch when there are no changes to be commited.
On JunOS ~14, `ndev.rpc.get_configuration( :compare=>'rollback', :rollback=> rollback_id.to_s )`returns an xml response:
```
<configuration-information>
<configuration-output>
</configuration-output>
</configuration-information>
```
But on JunOS ~17, the same method call, returns `nil` making the subsequent line to fail with `undefined method 'xpath' for nil:NilClass`

Adding `:format => 'text'` to the call seems to make the behavior consistent across different JunOS versions


PS: I took the idea from the more up to date python library https://github.com/Juniper/py-junos-eznc/blob/ce914d19030f51067b0c02c72fd69557f26c49e9/lib/jnpr/junos/utils/config.py#L225