### PR TITLE
Support of re-name, "LOCALRE"

### DIFF
--- a/lib/junos-ez/facts/version.rb
+++ b/lib/junos-ez/facts/version.rb
@@ -43,6 +43,7 @@ Junos::Ez::Facts::Keeper.define( :version ) do |ndev, facts|
     unless master_id.nil?
       facts[:version] = 
         facts[("version_" + "RE" + master_id).to_sym] || 
+        facts[("version_" + "LOCALRE").to_sym] ||
         facts[('version_' + "FPC" + master_id).to_sym]
     end
   else


### PR DESCRIPTION
Normally, REs are expected to be named as RE0 or RE1. But on some versions of QFX, REs are named as LOCALRE. This code patch accommodates this deviation in naming convention and returns the version number of LOCALRE.